### PR TITLE
Added: Digital Bodleian

### DIFF
--- a/Bodleian/bodleian.json
+++ b/Bodleian/bodleian.json
@@ -1,0 +1,14 @@
+{
+    "id": "https://www.bodleian.ox.ac.uk/",
+    "institution": { "en" : ["Bodleian Libraries, University of Oxford"] },
+    "provider": {
+        "id": "https://digital.bodleian.ox.ac.uk",
+        "label": { "en": ["Digital Bodleian: Bodleian Libraries and Oxford College Libraries"] }
+    },
+    "streams": [
+        {
+            "id": "https://iiif.bodleian.ox.ac.uk/iiif/activity/all-changes",
+            "label": {"en": ["All changes"]} 
+        }
+    ]
+}


### PR DESCRIPTION
I know the registry is probably unofficial at this point, but I thought I would have a go at adding a new entry for Digital Bodleian. Feel free to reject if it's too soon!

I may have slightly bent the definition of 'provider', since we aggregate content from other Oxford libraries. 